### PR TITLE
Trustworthy verdicts: INCOMPLETE marking and overflight exclusion

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -210,8 +210,16 @@ function commandSummarize(argv: string[]): void {
 function formatRuleResult(result: RuleResult): string {
   const lines: string[] = [];
   lines.push(`\n${result.rule.title}  [${result.rule.id}]`);
-  const glyph = (ok: boolean) => (ok ? "PASS" : "FAIL");
   for (const period of result.periods) {
+    // An incomplete period must never render its untrustworthy direction as
+    // a plain verdict (at-least: FAIL could flip; at-most: PASS could flip).
+    const glyph = (ok: boolean) => {
+      const untrustworthy = period.comparison === "at-least" ? !ok : ok;
+      if (period.incomplete && untrustworthy) {
+        return "INCOMPLETE";
+      }
+      return ok ? "PASS" : "FAIL";
+    };
     const margin =
       period.comparison === "at-least"
         ? period.observedDays - period.threshold

--- a/src/ingest/timeline.ts
+++ b/src/ingest/timeline.ts
@@ -16,6 +16,8 @@ import type { Observation, ObservationSource } from "../types.ts";
 export interface ExtractStats {
   semanticSegments: number;
   rawPositionSignals: number;
+  /** Activity segments Google labeled as FLYING. */
+  flyingSegments: number;
   observations: number;
   malformedEntries: number;
 }
@@ -48,9 +50,11 @@ export function extractObservations(exportJson: unknown): ExtractResult {
   }
 
   const observations: Observation[] = [];
+  const flyingWindows: Array<{ start: number; end: number }> = [];
   const stats: ExtractStats = {
     semanticSegments: segments.length,
     rawPositionSignals: 0,
+    flyingSegments: 0,
     observations: 0,
     malformedEntries: 0,
   };
@@ -73,12 +77,32 @@ export function extractObservations(exportJson: unknown): ExtractResult {
       startTime?: unknown;
       endTime?: unknown;
       visit?: { topCandidate?: { placeLocation?: { latLng?: unknown } } };
-      activity?: { start?: { latLng?: unknown }; end?: { latLng?: unknown } };
+      activity?: {
+        start?: { latLng?: unknown };
+        end?: { latLng?: unknown };
+        topCandidate?: { type?: unknown };
+      };
       timelinePath?: unknown;
     };
     if (!segment || typeof segment !== "object") {
       stats.malformedEntries += 1;
       continue;
+    }
+
+    // Google labels transport mode per activity segment. FLYING windows let
+    // us tag en-route fixes (which live in concurrent timelinePath segments
+    // and rawSignals) as airborne — flying over a country is not presence.
+    if (
+      typeof segment.activity?.topCandidate?.type === "string" &&
+      segment.activity.topCandidate.type.toUpperCase() === "FLYING" &&
+      isValidTimestamp(segment.startTime) &&
+      isValidTimestamp(segment.endTime)
+    ) {
+      stats.flyingSegments += 1;
+      flyingWindows.push({
+        start: Date.parse(segment.startTime),
+        end: Date.parse(segment.endTime),
+      });
     }
 
     if (segment.visit) {
@@ -120,6 +144,25 @@ export function extractObservations(exportJson: unknown): ExtractResult {
     }
     stats.rawPositionSignals += 1;
     add(signal.position.LatLng ?? signal.position.latLng, signal.position.timestamp, "raw_position");
+  }
+
+  // Tag observations strictly inside a FLYING window as airborne. Window
+  // endpoints stay untagged: they are the departure/arrival airports, which
+  // are genuine ground presence.
+  if (flyingWindows.length > 0) {
+    flyingWindows.sort((a, b) => a.start - b.start);
+    for (const observation of observations) {
+      const epoch = Date.parse(observation.time);
+      for (const window of flyingWindows) {
+        if (window.start >= epoch) {
+          break;
+        }
+        if (epoch < window.end) {
+          observation.airborne = true;
+          break;
+        }
+      }
+    }
   }
 
   stats.observations = observations.length;

--- a/src/presence/days.ts
+++ b/src/presence/days.ts
@@ -56,6 +56,8 @@ export interface PresenceModel {
 
 interface DayAccumulator {
   regions: Map<string, DayRegionPresence>;
+  /** Non-airborne observation count per region key. */
+  groundCounts: Map<string, number>;
   lastEpoch: number;
   lastCountry: string | null;
   firstEpoch: number;
@@ -68,6 +70,66 @@ function regionKey(resolution: RegionResolution): string {
   return resolution.codes.length > 0
     ? resolution.codes[resolution.codes.length - 1]!
     : resolution.country;
+}
+
+/**
+ * Overflight detection. Two signals mark a fix as airborne:
+ *  1. Google's own FLYING activity windows (tagged at ingest, authoritative).
+ *  2. A speed heuristic between consecutive fixes — fallback for raw
+ *     positions, unlabeled legs, and teleporting stale WiFi fixes.
+ * Regions evidenced ONLY by airborne fixes are flight-path artifacts —
+ * flying over Cuba is not presence in Cuba — kept in the day record but
+ * flagged and never counted.
+ *
+ * 400 km/h clears every train (~320 max); the 40 km distance floor keeps GPS
+ * jitter between rapid nearby fixes from reading as supersonic.
+ */
+const AIRBORNE_MIN_KMH = 400;
+const AIRBORNE_MIN_LEG_KM = 40;
+
+function haversineKm(
+  a: { lat: number; lng: number },
+  b: { lat: number; lng: number }
+): number {
+  const rad = Math.PI / 180;
+  const dLat = (b.lat - a.lat) * rad;
+  const dLng = (b.lng - a.lng) * rad;
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(a.lat * rad) * Math.cos(b.lat * rad) * Math.sin(dLng / 2) ** 2;
+  return 2 * 6371 * Math.asin(Math.sqrt(h));
+}
+
+interface TaggedObservation {
+  observation: Observation;
+  epoch: number;
+  airborne: boolean;
+}
+
+function tagAirborne(observations: Observation[]): TaggedObservation[] {
+  const tagged: TaggedObservation[] = observations
+    .map((observation) => ({
+      observation,
+      epoch: Date.parse(observation.time),
+      airborne: observation.airborne === true,
+    }))
+    .filter((t) => Number.isFinite(t.epoch))
+    .sort((a, b) => a.epoch - b.epoch);
+
+  for (let i = 1; i < tagged.length; i += 1) {
+    const prev = tagged[i - 1]!;
+    const current = tagged[i]!;
+    const hours = (current.epoch - prev.epoch) / 3_600_000;
+    if (hours <= 0) {
+      continue;
+    }
+    const km = haversineKm(prev.observation, current.observation);
+    if (km >= AIRBORNE_MIN_LEG_KM && km / hours >= AIRBORNE_MIN_KMH) {
+      prev.airborne = true;
+      current.airborne = true;
+    }
+  }
+  return tagged;
 }
 
 function gapConfidence(gapDays: number): InferenceConfidence {
@@ -91,7 +153,7 @@ export function buildPresenceModel(
 
   const yearFilter = options.years ? new Set(options.years.map(String)) : null;
 
-  for (const observation of observations) {
+  for (const { observation, epoch, airborne } of tagAirborne(observations)) {
     const day = dayKeyOfTimestamp(observation.time);
     if (!day || day > today) {
       outOfScope += 1;
@@ -104,12 +166,12 @@ export function buildPresenceModel(
 
     const resolution = resolve(observation.lat, observation.lng);
     const key = regionKey(resolution);
-    const epoch = Date.parse(observation.time);
 
     let accumulator = accumulators.get(day);
     if (!accumulator) {
       accumulator = {
         regions: new Map(),
+        groundCounts: new Map(),
         lastEpoch: -Infinity,
         lastCountry: null,
         lastCodes: [],
@@ -143,6 +205,10 @@ export function buildPresenceModel(
       }
     }
 
+    if (airborne) {
+      continue; // airborne fixes never anchor day boundaries or ground counts
+    }
+    accumulator.groundCounts.set(key, (accumulator.groundCounts.get(key) ?? 0) + 1);
     if (epoch >= accumulator.lastEpoch) {
       accumulator.lastEpoch = epoch;
       accumulator.lastCountry = resolution.country;
@@ -178,9 +244,26 @@ export function buildPresenceModel(
         };
         continue;
       }
-      const regions = Array.from(accumulator.regions.values()).sort(
-        (a, b) => b.observationCount - a.observationCount
-      );
+      // Regions whose only evidence is airborne fixes are overflight
+      // artifacts (countries flown over, teleporting stale fixes). They are
+      // not presence and are dropped from the output entirely.
+      const regions: DayRegionPresence[] = [];
+      for (const [key, presence] of accumulator.regions) {
+        if ((accumulator.groundCounts.get(key) ?? 0) > 0) {
+          regions.push(presence);
+        }
+      }
+      if (regions.length === 0) {
+        // Every fix that day was airborne: no presence anywhere.
+        history[day] = {
+          date: day,
+          status: "unknown",
+          regions: [],
+          endOfDayCountry: null,
+        };
+        continue;
+      }
+      regions.sort((a, b) => b.observationCount - a.observationCount);
       history[day] = {
         date: day,
         status: "observed",

--- a/src/report/html.ts
+++ b/src/report/html.ts
@@ -76,12 +76,24 @@ export function renderDashboard(
         .map((p) => {
           const ok = p.satisfiedObserved;
           const okInferred = p.satisfiedWithInferred;
+          // Incomplete = the formula reached outside loaded data and this
+          // verdict could flip; never render it as a plain PASS/FAIL.
+          const badge = (verdict: boolean, long: boolean) => {
+            const untrustworthy = p.comparison === "at-least" ? !verdict : verdict;
+            if (p.incomplete && untrustworthy) {
+              return `<span class="badge partial">◌ ${long ? "INCOMPLETE" : "?"}</span>`;
+            }
+            return verdict
+              ? `<span class="badge pass">✓${long ? " PASS" : ""}</span>`
+              : `<span class="badge fail">✕${long ? " FAIL" : ""}</span>`;
+          };
           return `<div class="rule-period">
             <div class="rule-period-label">${escapeHtml(p.period)}</div>
             <div class="rule-num">${p.observedDays}<span class="rule-thresh">/${p.comparison === "at-least" ? "≥" : "≤"}${p.threshold}</span></div>
-            <div class="badge ${ok ? "pass" : "fail"}">${ok ? "✓ PASS" : "✕ FAIL"} <span class="badge-sub">observed</span></div>
-            ${p.inferredDays > 0 ? `<div class="badge ${okInferred ? "pass" : "fail"} ghost">${okInferred ? "✓" : "✕"} ${p.totalDays} <span class="badge-sub">with inferred</span></div>` : ""}
+            <div>${badge(ok, true)} <span class="badge-sub">observed</span></div>
+            ${p.inferredDays > 0 ? `<div class="ghost">${badge(okInferred, false)} ${p.totalDays} <span class="badge-sub">with inferred</span></div>` : ""}
             ${p.unknownDays > 0 ? `<div class="caveat">${p.unknownDays} days unknown</div>` : ""}
+            ${p.incomplete ? `<div class="caveat">formula reaches outside loaded data</div>` : ""}
           </div>`;
         })
         .join("");
@@ -162,7 +174,8 @@ export function renderDashboard(
   .rule-thresh { font-size: 13px; color: var(--muted); font-weight: 400; }
   .badge { display: inline-block; font-size: 12px; font-weight: 600; margin-top: 2px; }
   .badge.pass { color: var(--good); } .badge.fail { color: var(--critical); }
-  .badge.ghost { opacity: 0.75; font-weight: 400; display: block; }
+  .badge.partial { color: var(--muted); }
+  .ghost { opacity: 0.75; font-weight: 400; font-size: 12px; }
   .badge-sub { color: var(--muted); font-weight: 400; }
   .caveat { font-size: 12px; color: var(--muted); }
   .notes { font-size: 12px; color: var(--muted); margin: 10px 0 0; }

--- a/src/rules/engine.ts
+++ b/src/rules/engine.ts
@@ -54,7 +54,7 @@ export function dayCounts(record: DayRecord, rule: RuleConfig): boolean {
     );
     return endPresence ? presenceMatches(rule.region, endPresence) : false;
   }
-  // any-presence
+  // any-presence (overflight regions are already excluded at build time)
   return record.regions.some((presence) => presenceMatches(rule.region, presence));
 }
 

--- a/src/rules/engine.ts
+++ b/src/rules/engine.ts
@@ -173,24 +173,47 @@ function evaluateRollingWindow(
   }
 
   const results: PeriodResult[] = [];
+  // A window reaching before the first loaded day is computed from partial
+  // data; a verdict that could flip with the missing days must not be
+  // presented as trustworthy.
+  const markIfTruncated = (result: PeriodResult, windowStart: string): PeriodResult => {
+    if (windowStart < first) {
+      result.detail =
+        (result.detail ?? "") +
+        ` Window starts ${windowStart}, before the first loaded day (${first}) — partial data.`;
+      const couldFlip =
+        rule.comparison === "at-least" ? !result.satisfiedObserved : result.satisfiedObserved;
+      if (couldFlip) {
+        result.incomplete = true;
+      }
+    }
+    return result;
+  };
+
   if (peak) {
     results.push(
-      buildPeriodResult(
-        `peak ${windowDays}-day window ending ${peak.end}`,
-        peak.window,
-        rule,
-        `Highest count of matching days in any ${windowDays}-day window.`
+      markIfTruncated(
+        buildPeriodResult(
+          `peak ${windowDays}-day window ending ${peak.end}`,
+          peak.window,
+          rule,
+          `Highest count of matching days in any ${windowDays}-day window.`
+        ),
+        addDays(peak.end, -(windowDays - 1))
       )
     );
   }
   const latestStart = addDays(last, -(windowDays - 1));
   const latestWindow = days.filter((d) => d.date >= latestStart && d.date <= last);
   results.push(
-    buildPeriodResult(
-      `latest ${windowDays}-day window ending ${last}`,
-      latestWindow,
-      rule,
-      `Current standing as of the last day with data.`
+    markIfTruncated(
+      buildPeriodResult(
+        `latest ${windowDays}-day window ending ${last}`,
+        latestWindow,
+        rule,
+        `Current standing as of the last day with data.`
+      ),
+      latestStart
     )
   );
   return results;
@@ -206,18 +229,28 @@ function evaluateMultiYearWeighted(
   const years = Array.from(byYear.keys()).sort();
   const results: PeriodResult[] = [];
 
+  const loadedYears = new Set(years);
+
   for (const year of years) {
     const yearNumber = Number.parseInt(year, 10);
     let weightedObserved = 0;
     let weightedTotal = 0;
     const parts: string[] = [];
+    const missingYears: string[] = [];
     for (let i = 0; i < weights.length; i += 1) {
-      const contributing = byYear.get(String(yearNumber - i)) ?? [];
+      const referenced = String(yearNumber - i);
+      if (!loadedYears.has(referenced)) {
+        // Counting an unloaded year as 0 would silently corrupt the verdict.
+        missingYears.push(referenced);
+        parts.push(`${referenced}: not loaded`);
+        continue;
+      }
+      const contributing = byYear.get(referenced) ?? [];
       const observed = contributing.filter((d) => d.observed).length;
       const total = contributing.filter((d) => d.observed || d.inferred).length;
       weightedObserved += observed * weights[i]!;
       weightedTotal += total * weights[i]!;
-      parts.push(`${yearNumber - i}: ${total} x ${weights[i]}`);
+      parts.push(`${referenced}: ${total} x ${weights[i]}`);
     }
 
     const currentYearDays = byYear.get(year) ?? [];
@@ -245,10 +278,24 @@ function evaluateMultiYearWeighted(
       unknownDays: currentYearDays.filter((d) => d.unknown).length,
       detail:
         `Weighted days = ${parts.join(" + ")}` +
+        (missingYears.length > 0
+          ? `; ${missingYears.join(", ")} not loaded (year filter?) — the verdict cannot be trusted until the full window is loaded`
+          : "") +
         (minCurrentYearDays !== undefined
           ? `; requires >= ${minCurrentYearDays} days in ${year} itself`
           : ""),
     };
+    if (missingYears.length > 0) {
+      result.missingYears = missingYears;
+      // Only untrustworthy verdicts are marked incomplete: for an at-least
+      // test, missing data can only ADD days, so a PASS stands but a FAIL
+      // could flip (and vice versa for at-most).
+      const couldFlip =
+        rule.comparison === "at-least" ? !result.satisfiedObserved : result.satisfiedObserved;
+      if (couldFlip) {
+        result.incomplete = true;
+      }
+    }
     results.push(result);
   }
   return results;

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,6 +132,16 @@ export interface PeriodResult {
   satisfiedWithInferred: boolean;
   /** Days in the period with no data at all (coverage gap warning). */
   unknownDays: number;
+  /**
+   * Set when the period's formula reaches outside the loaded data (e.g. a
+   * 3-year test evaluated with prior years excluded by --years, or a rolling
+   * window extending before the first loaded day) AND the verdict could flip
+   * if that data were present. An incomplete verdict must never be displayed
+   * as a plain PASS/FAIL.
+   */
+  incomplete?: boolean;
+  /** Years the formula referenced but that are absent from the loaded data. */
+  missingYears?: string[];
   detail?: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,11 @@ export interface Observation {
   lng: number;
   /** Which export structure this came from. */
   source: ObservationSource;
+  /**
+   * True when the fix falls inside a Google-labeled FLYING activity window.
+   * Airborne fixes never establish presence (see overflight handling).
+   */
+  airborne?: boolean;
 }
 
 export type ObservationSource =

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -105,3 +105,34 @@ test("archive merge is idempotent and splits by year", () => {
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test("fixes inside a Google FLYING window are tagged airborne; airports are not", () => {
+  const { observations, stats } = extractObservations({
+    semanticSegments: [
+      {
+        startTime: "2024-03-14T15:00:00.000-04:00",
+        endTime: "2024-03-14T18:00:00.000-04:00",
+        activity: {
+          topCandidate: { type: "FLYING" },
+          start: { latLng: "18.4655°, -66.1057°" },
+          end: { latLng: "40.7128°, -74.0060°" },
+        },
+      },
+      {
+        startTime: "2024-03-14T15:00:00.000-04:00",
+        endTime: "2024-03-14T18:00:00.000-04:00",
+        timelinePath: [
+          { point: "22.0°, -78.6°", time: "2024-03-14T16:30:00.000-04:00" }, // en route
+        ],
+      },
+    ],
+  });
+  assert.equal(stats.flyingSegments, 1);
+  const enRoute = observations.find((o) => o.source === "timeline_path")!;
+  assert.equal(enRoute.airborne, true);
+  // Departure/arrival airport fixes are genuine ground presence.
+  const takeoff = observations.find((o) => o.source === "activity_start")!;
+  const landing = observations.find((o) => o.source === "activity_end")!;
+  assert.notEqual(takeoff.airborne, true);
+  assert.notEqual(landing.airborne, true);
+});

--- a/test/presence.test.ts
+++ b/test/presence.test.ts
@@ -106,3 +106,65 @@ test("years default to those present in the data", () => {
   assert.deepEqual(model.stats.yearsIncluded, [2023, 2024]);
   assert.equal(model.stats.daysTotal, 365 + 366); // 2023 + leap 2024
 });
+
+test("countries merely flown over never appear in the day's regions", () => {
+  // SJU -> NYC flight: the path fix over central Cuba implies ~860 km/h
+  // legs — airborne. Cuba is overflight, not presence, and must be absent
+  // from the output entirely. PR and US keep their ground evidence.
+  const centralCuba = { lat: 22.0, lng: -78.6 };
+  const model = buildPresenceModel(
+    [
+      obs("2024-03-14T08:00:00.000-04:00", LANDMARKS.sanJuanPR),
+      obs("2024-03-14T14:00:00.000-04:00", LANDMARKS.sanJuanPR),
+      obs("2024-03-14T15:30:00.000-04:00", centralCuba, "timeline_path"),
+      obs("2024-03-14T18:30:00.000-04:00", LANDMARKS.nycUS),
+      obs("2024-03-14T21:00:00.000-04:00", LANDMARKS.nycUS),
+    ],
+    resolve,
+    { years: [2024], fillMissingDays: false, todayKey: "2025-01-01" }
+  );
+  const day = model.history["2024-03-14"]!;
+  const countries = day.regions.map((r) => r.country).sort();
+  assert.deepEqual(countries, ["Puerto Rico", "United States of America"]);
+});
+
+test("Google-labeled airborne fixes are excluded even at ground speeds", () => {
+  // Paris -> Brussels over 11 hours (~24 km/h implied): the speed heuristic
+  // stays silent, so ONLY the ingest-time FLYING flag can exclude Belgium.
+  const model = buildPresenceModel(
+    [
+      obs("2024-03-14T08:00:00.000+01:00", LANDMARKS.parisFR),
+      obs("2024-03-14T09:00:00.000+01:00", LANDMARKS.parisFR),
+      { ...obs("2024-03-14T20:00:00.000+01:00", { lat: 50.85, lng: 4.35 }), airborne: true },
+    ],
+    resolve,
+    { years: [2024], fillMissingDays: false, todayKey: "2025-01-01" }
+  );
+  const day = model.history["2024-03-14"]!;
+  assert.deepEqual(day.regions.map((r) => r.country), ["France"]);
+});
+
+test("a day with only airborne fixes has no presence at all", () => {
+  const model = buildPresenceModel(
+    [{ ...obs("2024-03-14T12:00:00.000+00:00", LANDMARKS.parisFR), airborne: true }],
+    resolve,
+    { years: [2024], fillMissingDays: false, todayKey: "2025-01-01" }
+  );
+  assert.equal(model.history["2024-03-14"]!.status, "unknown");
+  assert.deepEqual(model.history["2024-03-14"]!.regions, []);
+});
+
+test("fast ground travel is not mistaken for flying", () => {
+  // ~230 km in 1h = high-speed rail; both ends must count.
+  const model = buildPresenceModel(
+    [
+      obs("2024-03-14T08:00:00.000+01:00", LANDMARKS.parisFR),
+      obs("2024-03-14T09:00:00.000+01:00", { lat: 50.63, lng: 3.07 }), // Lille
+    ],
+    resolve,
+    { years: [2024], fillMissingDays: false, todayKey: "2025-01-01" }
+  );
+  const day = model.history["2024-03-14"]!;
+  assert.deepEqual(day.regions.map((r) => r.country), ["France"]);
+  assert.equal(day.regions[0]?.observationCount, 2);
+});

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -208,3 +208,56 @@ test("custom rule files load and validate with clear errors", () => {
     /Unknown rule 'does-not-exist'. Built-in presets:/
   );
 });
+
+// --- incomplete verdicts: formulas must not silently treat unloaded years as 0 ---
+
+test("multi-year test marks FAIL as INCOMPLETE when prior years are not loaded", () => {
+  const rule = loadRule("pr-presence-549-3yr");
+  // Only 2024 loaded: 200 days < 549. With 2022-2023 loaded this could pass,
+  // so the FAIL is untrustworthy and must be flagged.
+  const result = evaluateRule(historyOf(fillYear(2024, PR, 1, 200)), rule);
+  const y2024 = result.periods.find((p) => p.period === "2024")!;
+  assert.equal(y2024.satisfiedObserved, false);
+  assert.equal(y2024.incomplete, true);
+  assert.deepEqual(y2024.missingYears, ["2023", "2022"]);
+  assert.match(y2024.detail ?? "", /not loaded/);
+});
+
+test("multi-year PASS with missing years stays a trustworthy PASS", () => {
+  // Missing years can only ADD days to an at-least test: a PASS cannot flip.
+  const rule = loadRule("pr-presence-549-3yr");
+  const result = evaluateRule(historyOf(fillYear(2024, PR, 1, 300)), rule);
+  // 300 < 549 -> still fails; use a custom threshold via SPT instead:
+  const spt = loadRule("us-substantial-presence");
+  const sptResult = evaluateRule(historyOf(fillYear(2024, US, 1, 200)), spt);
+  const y2024 = sptResult.periods.find((p) => p.period === "2024")!;
+  assert.equal(y2024.satisfiedObserved, true); // 200 >= 183 on current year alone
+  assert.notEqual(y2024.incomplete, true); // missing 2022/2023 cannot flip a PASS
+  assert.deepEqual(y2024.missingYears, ["2023", "2022"]);
+  void result;
+});
+
+test("multi-year test with all referenced years loaded is never incomplete", () => {
+  const rule = loadRule("pr-presence-549-3yr");
+  const history = historyOf([
+    ...fillYear(2022, PR, 1, 183),
+    ...fillYear(2023, PR, 1, 183),
+    ...fillYear(2024, PR, 1, 183),
+  ]);
+  const result = evaluateRule(history, rule);
+  const y2024 = result.periods.find((p) => p.period === "2024")!;
+  assert.equal(y2024.incomplete, undefined);
+  assert.equal(y2024.missingYears, undefined);
+});
+
+test("rolling window PASS is INCOMPLETE when the window predates loaded data", () => {
+  const rule = loadRule("schengen-90-180");
+  // 30 France days at the start of the loaded span: the latest 180-day
+  // window reaches before the first loaded day, so an at-most PASS could
+  // flip if earlier days were loaded.
+  const result = evaluateRule(historyOf(fillYear(2024, FR, 1, 30)), rule);
+  const latest = result.periods.find((p) => p.period.startsWith("latest"))!;
+  assert.equal(latest.satisfiedObserved, true);
+  assert.equal(latest.incomplete, true);
+  assert.match(latest.detail ?? "", /before the first loaded day/);
+});


### PR DESCRIPTION
Two correctness fixes for how presence is counted and reported, both found by real-data auditing.

## 1. Verdicts are marked INCOMPLETE when the formula exceeds loaded data

A multi-year test (549/3yr, SPT) evaluated under a `--years` filter silently counted unloaded years as 0 days, rendering false FAILs; rolling windows reaching before the first loaded day could render false PASSes. Such verdicts now display `INCOMPLETE` with the missing years named in the detail line, in the CLI and the dashboard. Verdicts that cannot flip (an at-least PASS, an at-most FAIL) stay plain — missing data can only add days.

## 2. Countries merely flown over no longer appear anywhere

Flight-path fixes created phantom presence (a PR↔US flight corridor produced "days" in Cuba and the Bahamas; one 2019 Tokyo→Europe day was attributed to a country only reached the next day). Overflight regions are now excluded from all output at build time, using two signals:

- **Google's own FLYING activity labels** — the export marks transport mode per activity segment; fixes strictly inside a FLYING window are tagged airborne at ingest (departure/arrival airport endpoints stay ground presence).
- **A speed heuristic as fallback** — legs ≥400 km/h over ≥40 km (faster than any train) mark both endpoint fixes airborne, catching unlabeled legs, raw positions, and teleporting stale-WiFi fixes.

A region with no ground evidence in a day is dropped entirely; a day that is fully airborne has no presence at all.

**Real-data regression vs the pinned v1 baseline:** the only diffs from this change are removed overflight artifacts (phantom travel-day countries) and one corrected 2019 travel day. Suite grows to 48 tests, including flag-only exclusion (slow-speed case), heuristic-only exclusion, high-speed-rail non-exclusion, and airport-endpoint ground presence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)